### PR TITLE
Add multiple Flutter package examples

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,21 @@
 import 'package:flutter/material.dart';
 import 'package:device_info_example/device_info_example.dart';
 import 'package:url_launcher_example/url_launcher_example.dart';
+import 'package:hive_example/hive_example.dart';
+import 'package:camera_example/camera_example.dart';
+import 'package:sqflite_example/sqflite_example.dart';
+import 'package:video_player_example/video_player_example.dart';
+import 'package:carousel_slider_example/carousel_slider_example.dart';
+import 'package:dots_indicator_example/dots_indicator_example.dart';
+import 'package:flutter_cache_manager_example/flutter_cache_manager_example.dart';
+import 'package:flutter_downloader_example/flutter_downloader_example.dart';
+import 'package:flutter_staggered_grid_view_example/flutter_staggered_grid_view_example.dart';
+import 'package:flutter_svg_lottie_example/flutter_svg_lottie_example.dart';
+import 'package:http_example/http_example.dart';
+import 'package:image_picker_example/image_picker_example.dart';
+import 'package:in_app_review_example/in_app_review_example.dart';
+import 'package:get_it_example/get_it_example.dart';
+import 'package:intl_logger_example/intl_logger_example.dart';
 
 void main() {
   runApp(const MyApp());
@@ -50,6 +65,21 @@ class MyHomePage extends StatelessWidget {
     final examples = <String, WidgetBuilder>{
       "Device Info Example": (context) => const DeviceInfoExamplePage(),
       "URL Launcher Example": (context) => const UrlLauncherExamplePage(),
+      "Hive Example": (context) => const HiveExamplePage(),
+      "Camera Example": (context) => const CameraExamplePage(),
+      "Sqflite Example": (context) => const SqfliteExamplePage(),
+      "Video Player Example": (context) => const VideoPlayerExamplePage(),
+      "Carousel Slider Example": (context) => const CarouselSliderExamplePage(),
+      "Dots Indicator Example": (context) => const DotsIndicatorExamplePage(),
+      "Cache Manager Example": (context) => const FlutterCacheManagerExamplePage(),
+      "Downloader Example": (context) => const FlutterDownloaderExamplePage(),
+      "Staggered Grid Example": (context) => const FlutterStaggeredGridViewExamplePage(),
+      "SVG & Lottie Example": (context) => const FlutterSvgLottieExamplePage(),
+      "HTTP Example": (context) => const HttpExamplePage(),
+      "Image Picker Example": (context) => const ImagePickerExamplePage(),
+      "In App Review Example": (context) => const InAppReviewExamplePage(),
+      "GetIt Example": (context) => const GetItExamplePage(),
+      "Intl & Logger Example": (context) => IntlLoggerExamplePage(),
     };
 
     return Scaffold(

--- a/packages/camera_example/lib/camera_example.dart
+++ b/packages/camera_example/lib/camera_example.dart
@@ -1,0 +1,51 @@
+import 'package:camera/camera.dart';
+import 'package:flutter/material.dart';
+
+class CameraExamplePage extends StatefulWidget {
+  const CameraExamplePage({super.key});
+
+  @override
+  State<CameraExamplePage> createState() => _CameraExamplePageState();
+}
+
+class _CameraExamplePageState extends State<CameraExamplePage> {
+  late CameraController _controller;
+  Future<void>? _initializeControllerFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _setup();
+  }
+
+  Future<void> _setup() async {
+    final cameras = await availableCameras();
+    final camera = cameras.first;
+    _controller = CameraController(camera, ResolutionPreset.medium);
+    _initializeControllerFuture = _controller.initialize();
+    setState(() {});
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Camera Example')),
+      body: FutureBuilder(
+        future: _initializeControllerFuture,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.done) {
+            return CameraPreview(_controller);
+          } else {
+            return const Center(child: CircularProgressIndicator());
+          }
+        },
+      ),
+    );
+  }
+}

--- a/packages/camera_example/pubspec.yaml
+++ b/packages/camera_example/pubspec.yaml
@@ -1,0 +1,12 @@
+name: camera_example
+description: A demo using camera
+version: 0.0.1
+publish_to: 'none'
+environment:
+  sdk: '>=3.4.3 <4.0.0'
+dependencies:
+  flutter:
+    sdk: flutter
+  camera: ^0.11.1
+flutter:
+

--- a/packages/carousel_slider_example/lib/carousel_slider_example.dart
+++ b/packages/carousel_slider_example/lib/carousel_slider_example.dart
@@ -1,0 +1,46 @@
+import 'package:carousel_slider/carousel_slider.dart';
+import 'package:flutter/material.dart';
+import 'package:percent_indicator/percent_indicator.dart';
+
+class CarouselSliderExamplePage extends StatefulWidget {
+  const CarouselSliderExamplePage({super.key});
+
+  @override
+  State<CarouselSliderExamplePage> createState() => _CarouselSliderExamplePageState();
+}
+
+class _CarouselSliderExamplePageState extends State<CarouselSliderExamplePage> {
+  int _current = 0;
+  final _items = [1, 2, 3];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Carousel Slider Example')),
+      body: Column(
+        children: [
+          CarouselSlider(
+            items: _items.map((e) => Container(
+                      color: Colors.grey,
+                      child: Center(child: Text('Item $e')),
+                    )).toList(),
+            options: CarouselOptions(
+              onPageChanged: (index, reason) {
+                setState(() {
+                  _current = index;
+                });
+              },
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: LinearPercentIndicator(
+              lineHeight: 8,
+              percent: (_current + 1) / _items.length,
+            ),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/packages/carousel_slider_example/pubspec.yaml
+++ b/packages/carousel_slider_example/pubspec.yaml
@@ -1,0 +1,13 @@
+name: carousel_slider_example
+description: A demo using carousel_slider and percent_indicator
+version: 0.0.1
+publish_to: 'none'
+environment:
+  sdk: '>=3.4.3 <4.0.0'
+dependencies:
+  flutter:
+    sdk: flutter
+  carousel_slider: ^5.1.1
+  percent_indicator: ^4.2.5
+flutter:
+

--- a/packages/dots_indicator_example/lib/dots_indicator_example.dart
+++ b/packages/dots_indicator_example/lib/dots_indicator_example.dart
@@ -1,0 +1,53 @@
+import 'package:dots_indicator/dots_indicator.dart';
+import 'package:flutter/material.dart';
+
+class DotsIndicatorExamplePage extends StatefulWidget {
+  const DotsIndicatorExamplePage({super.key});
+
+  @override
+  State<DotsIndicatorExamplePage> createState() => _DotsIndicatorExamplePageState();
+}
+
+class _DotsIndicatorExamplePageState extends State<DotsIndicatorExamplePage> {
+  final _pageController = PageController();
+  double _position = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    _pageController.addListener(() {
+      setState(() {
+        _position = _pageController.page ?? 0;
+      });
+    });
+  }
+
+  @override
+  void dispose() {
+    _pageController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Dots Indicator Example')),
+      body: Column(
+        children: [
+          SizedBox(
+            height: 200,
+            child: PageView(
+              controller: _pageController,
+              children: const [
+                Center(child: Text('Page 1')),
+                Center(child: Text('Page 2')),
+                Center(child: Text('Page 3')),
+              ],
+            ),
+          ),
+          DotsIndicator(dotsCount: 3, position: _position),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/dots_indicator_example/pubspec.yaml
+++ b/packages/dots_indicator_example/pubspec.yaml
@@ -1,0 +1,12 @@
+name: dots_indicator_example
+description: A demo using dots_indicator
+version: 0.0.1
+publish_to: 'none'
+environment:
+  sdk: '>=3.4.3 <4.0.0'
+dependencies:
+  flutter:
+    sdk: flutter
+  dots_indicator: ^4.0.1
+flutter:
+

--- a/packages/flutter_cache_manager_example/lib/flutter_cache_manager_example.dart
+++ b/packages/flutter_cache_manager_example/lib/flutter_cache_manager_example.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_cache_manager/flutter_cache_manager.dart';
+
+class FlutterCacheManagerExamplePage extends StatefulWidget {
+  const FlutterCacheManagerExamplePage({super.key});
+
+  @override
+  State<FlutterCacheManagerExamplePage> createState() => _FlutterCacheManagerExamplePageState();
+}
+
+class _FlutterCacheManagerExamplePageState extends State<FlutterCacheManagerExamplePage> {
+  late Future<FileInfo> _file;
+
+  @override
+  void initState() {
+    super.initState();
+    _file = DefaultCacheManager().getFileFromCache('https://flutter.dev/images/flutter-logo-sharing.png')
+        .then((value) => value ?? DefaultCacheManager().downloadFile('https://flutter.dev/images/flutter-logo-sharing.png'));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Cache Manager Example')),
+      body: FutureBuilder<FileInfo>(
+        future: _file,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.done && snapshot.hasData) {
+            return Image.file(snapshot.data!.file);
+          } else {
+            return const Center(child: CircularProgressIndicator());
+          }
+        },
+      ),
+    );
+  }
+}

--- a/packages/flutter_cache_manager_example/pubspec.yaml
+++ b/packages/flutter_cache_manager_example/pubspec.yaml
@@ -1,0 +1,12 @@
+name: flutter_cache_manager_example
+description: A demo using flutter_cache_manager
+version: 0.0.1
+publish_to: 'none'
+environment:
+  sdk: '>=3.4.3 <4.0.0'
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_cache_manager: ^3.4.1
+flutter:
+

--- a/packages/flutter_downloader_example/lib/flutter_downloader_example.dart
+++ b/packages/flutter_downloader_example/lib/flutter_downloader_example.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_downloader/flutter_downloader.dart';
+
+class FlutterDownloaderExamplePage extends StatefulWidget {
+  const FlutterDownloaderExamplePage({super.key});
+
+  @override
+  State<FlutterDownloaderExamplePage> createState() => _FlutterDownloaderExamplePageState();
+}
+
+class _FlutterDownloaderExamplePageState extends State<FlutterDownloaderExamplePage> {
+  String _taskId = '';
+
+  @override
+  void initState() {
+    super.initState();
+    FlutterDownloader.initialize();
+  }
+
+  Future<void> _startDownload() async {
+    final id = await FlutterDownloader.enqueue(
+      url: 'https://speed.hetzner.de/100MB.bin',
+      savedDir: '/sdcard/Download',
+      showNotification: true,
+      openFileFromNotification: true,
+    );
+    setState(() {
+      _taskId = id ?? '';
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Downloader Example')),
+      body: Center(
+        child: ElevatedButton(
+          onPressed: _startDownload,
+          child: Text(_taskId.isEmpty ? 'Start Download' : 'Task: $_taskId'),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/flutter_downloader_example/pubspec.yaml
+++ b/packages/flutter_downloader_example/pubspec.yaml
@@ -1,0 +1,12 @@
+name: flutter_downloader_example
+description: A demo using flutter_downloader
+version: 0.0.1
+publish_to: 'none'
+environment:
+  sdk: '>=3.4.3 <4.0.0'
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_downloader: ^1.12.0
+flutter:
+

--- a/packages/flutter_staggered_grid_view_example/lib/flutter_staggered_grid_view_example.dart
+++ b/packages/flutter_staggered_grid_view_example/lib/flutter_staggered_grid_view_example.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
+
+class FlutterStaggeredGridViewExamplePage extends StatelessWidget {
+  const FlutterStaggeredGridViewExamplePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Staggered Grid Example')),
+      body: MasonryGridView.count(
+        crossAxisCount: 2,
+        mainAxisSpacing: 4,
+        crossAxisSpacing: 4,
+        itemCount: 6,
+        itemBuilder: (context, index) => Container(
+          height: (index % 3 + 1) * 50,
+          color: Colors.teal[100 * ((index % 8) + 1)],
+        ),
+      ),
+    );
+  }
+}

--- a/packages/flutter_staggered_grid_view_example/pubspec.yaml
+++ b/packages/flutter_staggered_grid_view_example/pubspec.yaml
@@ -1,0 +1,12 @@
+name: flutter_staggered_grid_view_example
+description: A demo using flutter_staggered_grid_view
+version: 0.0.1
+publish_to: 'none'
+environment:
+  sdk: '>=3.4.3 <4.0.0'
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_staggered_grid_view: ^0.7.0
+flutter:
+

--- a/packages/flutter_svg_lottie_example/lib/flutter_svg_lottie_example.dart
+++ b/packages/flutter_svg_lottie_example/lib/flutter_svg_lottie_example.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:lottie/lottie.dart';
+
+class FlutterSvgLottieExamplePage extends StatelessWidget {
+  const FlutterSvgLottieExamplePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('SVG & Lottie Example')),
+      body: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          SvgPicture.network('https://dev.w3.org/SVG/tools/svgweb/samples/svg-files/android.svg', height: 100),
+          const SizedBox(height: 20),
+          Lottie.network('https://assets10.lottiefiles.com/packages/lf20_iwmd6pyr.json', height: 100),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/flutter_svg_lottie_example/pubspec.yaml
+++ b/packages/flutter_svg_lottie_example/pubspec.yaml
@@ -1,0 +1,13 @@
+name: flutter_svg_lottie_example
+description: A demo using flutter_svg and lottie
+version: 0.0.1
+publish_to: 'none'
+environment:
+  sdk: '>=3.4.3 <4.0.0'
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_svg: ^2.1.0
+  lottie: ^3.3.1
+flutter:
+

--- a/packages/get_it_example/lib/get_it_example.dart
+++ b/packages/get_it_example/lib/get_it_example.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
+
+class CounterService {
+  int value = 0;
+}
+
+final getIt = GetIt.instance..registerSingleton<CounterService>(CounterService());
+
+class GetItExamplePage extends StatefulWidget {
+  const GetItExamplePage({super.key});
+
+  @override
+  State<GetItExamplePage> createState() => _GetItExamplePageState();
+}
+
+class _GetItExamplePageState extends State<GetItExamplePage> {
+  final service = getIt<CounterService>();
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('GetIt Example')),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text('Value: ${service.value}'),
+            ElevatedButton(
+              onPressed: () => setState(() => service.value++),
+              child: const Text('Increment'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/packages/get_it_example/pubspec.yaml
+++ b/packages/get_it_example/pubspec.yaml
@@ -1,0 +1,12 @@
+name: get_it_example
+description: A demo using get_it
+version: 0.0.1
+publish_to: 'none'
+environment:
+  sdk: '>=3.4.3 <4.0.0'
+dependencies:
+  flutter:
+    sdk: flutter
+  get_it: ^8.0.3
+flutter:
+

--- a/packages/hive_example/lib/hive_example.dart
+++ b/packages/hive_example/lib/hive_example.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+class HiveExamplePage extends StatefulWidget {
+  const HiveExamplePage({super.key});
+
+  @override
+  State<HiveExamplePage> createState() => _HiveExamplePageState();
+}
+
+class _HiveExamplePageState extends State<HiveExamplePage> {
+  String _value = 'Loading...';
+
+  @override
+  void initState() {
+    super.initState();
+    _init();
+  }
+
+  Future<void> _init() async {
+    await Hive.initFlutter();
+    final box = await Hive.openBox('demo');
+    await box.put('foo', 'bar');
+    setState(() {
+      _value = box.get('foo');
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Hive Example')),
+      body: Center(child: Text(_value)),
+    );
+  }
+}

--- a/packages/hive_example/pubspec.yaml
+++ b/packages/hive_example/pubspec.yaml
@@ -1,0 +1,13 @@
+name: hive_example
+description: A demo using hive
+version: 0.0.1
+publish_to: 'none'
+environment:
+  sdk: '>=3.4.3 <4.0.0'
+dependencies:
+  flutter:
+    sdk: flutter
+  hive: ^2.2.3
+  hive_flutter: ^1.1.0
+flutter:
+

--- a/packages/http_example/lib/http_example.dart
+++ b/packages/http_example/lib/http_example.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+
+class HttpExamplePage extends StatefulWidget {
+  const HttpExamplePage({super.key});
+
+  @override
+  State<HttpExamplePage> createState() => _HttpExamplePageState();
+}
+
+class _HttpExamplePageState extends State<HttpExamplePage> {
+  String _response = 'Loading...';
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final res = await http.get(Uri.parse('https://example.com'));
+    setState(() {
+      _response = 'Status: ${res.statusCode}';
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('HTTP Example')),
+      body: Center(child: Text(_response)),
+    );
+  }
+}

--- a/packages/http_example/pubspec.yaml
+++ b/packages/http_example/pubspec.yaml
@@ -1,0 +1,12 @@
+name: http_example
+description: A demo using http
+version: 0.0.1
+publish_to: 'none'
+environment:
+  sdk: '>=3.4.3 <4.0.0'
+dependencies:
+  flutter:
+    sdk: flutter
+  http: ^1.4.0
+flutter:
+

--- a/packages/image_picker_example/lib/image_picker_example.dart
+++ b/packages/image_picker_example/lib/image_picker_example.dart
@@ -1,0 +1,39 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+
+class ImagePickerExamplePage extends StatefulWidget {
+  const ImagePickerExamplePage({super.key});
+
+  @override
+  State<ImagePickerExamplePage> createState() => _ImagePickerExamplePageState();
+}
+
+class _ImagePickerExamplePageState extends State<ImagePickerExamplePage> {
+  XFile? _image;
+
+  Future<void> _pick() async {
+    final picker = ImagePicker();
+    final image = await picker.pickImage(source: ImageSource.gallery);
+    setState(() {
+      _image = image;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Image Picker Example')),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            if (_image != null) Image.file(File(_image!.path), height: 100),
+            ElevatedButton(onPressed: _pick, child: const Text('Pick Image')),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/packages/image_picker_example/pubspec.yaml
+++ b/packages/image_picker_example/pubspec.yaml
@@ -1,0 +1,12 @@
+name: image_picker_example
+description: A demo using image_picker
+version: 0.0.1
+publish_to: 'none'
+environment:
+  sdk: '>=3.4.3 <4.0.0'
+dependencies:
+  flutter:
+    sdk: flutter
+  image_picker: ^1.1.2
+flutter:
+

--- a/packages/in_app_review_example/lib/in_app_review_example.dart
+++ b/packages/in_app_review_example/lib/in_app_review_example.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:in_app_review/in_app_review.dart';
+
+class InAppReviewExamplePage extends StatelessWidget {
+  const InAppReviewExamplePage({super.key});
+
+  Future<void> _review() async {
+    final review = InAppReview.instance;
+    if (await review.isAvailable()) {
+      review.requestReview();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('In App Review Example')),
+      body: Center(
+        child: ElevatedButton(
+          onPressed: _review,
+          child: const Text('Request Review'),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/in_app_review_example/pubspec.yaml
+++ b/packages/in_app_review_example/pubspec.yaml
@@ -1,0 +1,12 @@
+name: in_app_review_example
+description: A demo using in_app_review
+version: 0.0.1
+publish_to: 'none'
+environment:
+  sdk: '>=3.4.3 <4.0.0'
+dependencies:
+  flutter:
+    sdk: flutter
+  in_app_review: ^2.0.10
+flutter:
+

--- a/packages/intl_logger_example/lib/intl_logger_example.dart
+++ b/packages/intl_logger_example/lib/intl_logger_example.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:logger/logger.dart';
+
+class IntlLoggerExamplePage extends StatelessWidget {
+  IntlLoggerExamplePage({super.key});
+
+  final _logger = Logger();
+  final _formatter = DateFormat.yMd().add_jms();
+
+  @override
+  Widget build(BuildContext context) {
+    final now = DateTime.now();
+    final formatted = _formatter.format(now);
+    _logger.i('Formatted date: $formatted');
+    return Scaffold(
+      appBar: AppBar(title: const Text('Intl & Logger Example')),
+      body: Center(child: Text(formatted)),
+    );
+  }
+}

--- a/packages/intl_logger_example/pubspec.yaml
+++ b/packages/intl_logger_example/pubspec.yaml
@@ -1,0 +1,13 @@
+name: intl_logger_example
+description: A demo using intl and logger
+version: 0.0.1
+publish_to: 'none'
+environment:
+  sdk: '>=3.4.3 <4.0.0'
+dependencies:
+  flutter:
+    sdk: flutter
+  intl: ^0.20.2
+  logger: ^2.5.0
+flutter:
+

--- a/packages/sqflite_example/lib/sqflite_example.dart
+++ b/packages/sqflite_example/lib/sqflite_example.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:sqflite/sqflite.dart';
+import 'package:path/path.dart';
+
+class SqfliteExamplePage extends StatefulWidget {
+  const SqfliteExamplePage({super.key});
+
+  @override
+  State<SqfliteExamplePage> createState() => _SqfliteExamplePageState();
+}
+
+class _SqfliteExamplePageState extends State<SqfliteExamplePage> {
+  String _text = 'Loading...';
+
+  @override
+  void initState() {
+    super.initState();
+    _setup();
+  }
+
+  Future<void> _setup() async {
+    final database = openDatabase(
+      join(await getDatabasesPath(), 'demo.db'),
+      onCreate: (db, version) {
+        return db.execute(
+          'CREATE TABLE demo(id INTEGER PRIMARY KEY, value TEXT)',
+        );
+      },
+      version: 1,
+    );
+    final db = await database;
+    await db.insert('demo', {'id': 0, 'value': 'example'},
+        conflictAlgorithm: ConflictAlgorithm.replace);
+    final result = await db.query('demo');
+    setState(() {
+      _text = result.first['value'] as String;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Sqflite Example')),
+      body: Center(child: Text(_text)),
+    );
+  }
+}

--- a/packages/sqflite_example/pubspec.yaml
+++ b/packages/sqflite_example/pubspec.yaml
@@ -1,0 +1,13 @@
+name: sqflite_example
+description: A demo using sqflite
+version: 0.0.1
+publish_to: 'none'
+environment:
+  sdk: '>=3.4.3 <4.0.0'
+dependencies:
+  flutter:
+    sdk: flutter
+  sqflite: ^2.4.2
+  path: ^1.9.0
+flutter:
+

--- a/packages/video_player_example/lib/video_player_example.dart
+++ b/packages/video_player_example/lib/video_player_example.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:video_player/video_player.dart';
+
+class VideoPlayerExamplePage extends StatefulWidget {
+  const VideoPlayerExamplePage({super.key});
+
+  @override
+  State<VideoPlayerExamplePage> createState() => _VideoPlayerExamplePageState();
+}
+
+class _VideoPlayerExamplePageState extends State<VideoPlayerExamplePage> {
+  late VideoPlayerController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = VideoPlayerController.network(
+      'https://flutter.github.io/assets-for-api-docs/assets/videos/butterfly.mp4',
+    )..initialize().then((_) {
+        setState(() {});
+        _controller.play();
+      });
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Video Player Example')),
+      body: Center(
+        child: _controller.value.isInitialized
+            ? AspectRatio(
+                aspectRatio: _controller.value.aspectRatio,
+                child: VideoPlayer(_controller),
+              )
+            : const CircularProgressIndicator(),
+      ),
+    );
+  }
+}

--- a/packages/video_player_example/pubspec.yaml
+++ b/packages/video_player_example/pubspec.yaml
@@ -1,0 +1,12 @@
+name: video_player_example
+description: A demo using video_player
+version: 0.0.1
+publish_to: 'none'
+environment:
+  sdk: '>=3.4.3 <4.0.0'
+dependencies:
+  flutter:
+    sdk: flutter
+  video_player: ^2.10.0
+flutter:
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,36 @@ dependencies:
     path: packages/device_info_example
   url_launcher_example:
     path: packages/url_launcher_example
+  hive_example:
+    path: packages/hive_example
+  camera_example:
+    path: packages/camera_example
+  sqflite_example:
+    path: packages/sqflite_example
+  video_player_example:
+    path: packages/video_player_example
+  carousel_slider_example:
+    path: packages/carousel_slider_example
+  dots_indicator_example:
+    path: packages/dots_indicator_example
+  flutter_cache_manager_example:
+    path: packages/flutter_cache_manager_example
+  flutter_downloader_example:
+    path: packages/flutter_downloader_example
+  flutter_staggered_grid_view_example:
+    path: packages/flutter_staggered_grid_view_example
+  flutter_svg_lottie_example:
+    path: packages/flutter_svg_lottie_example
+  http_example:
+    path: packages/http_example
+  image_picker_example:
+    path: packages/image_picker_example
+  in_app_review_example:
+    path: packages/in_app_review_example
+  get_it_example:
+    path: packages/get_it_example
+  intl_logger_example:
+    path: packages/intl_logger_example
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
## Summary
- showcase more Flutter plugins with new example packages
- list all new examples in `pubspec.yaml`
- link the examples from the main app

## Testing
- `flutter test` *(fails: command not found)*
- `dart format --output none --set-exit-if-changed .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d847b775883208048b654f5595824