### PR TITLE
Update AGP to 8.6.0

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "7.3.0" apply false
+    id "com.android.application" version "8.6.0" apply false
     id "org.jetbrains.kotlin.android" version "1.7.10" apply false
 }
 


### PR DESCRIPTION
## Summary
- bump Android Gradle plugin to 8.6.0
- update Gradle wrapper to 8.7 for compatibility

## Testing
- `curl -I https://services.gradle.org/distributions/gradle-8.7-all.zip`


------
https://chatgpt.com/codex/tasks/task_e_684dca221e948320a7d14dfe950ad039