### PR TITLE
Update Kotlin Gradle plugin to 2.1.21

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.6.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.7.10" apply false
+    id "org.jetbrains.kotlin.android" version "2.1.21" apply false
 }
 
 include ":app"


### PR DESCRIPTION
## Summary
- update the Kotlin Gradle plugin version in `android/settings.gradle`

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684dcbcf51508320a5ed1c3caf302a4f