### PR TITLE
Add Flutter splash screen

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'dart:async';
 import 'package:device_info_example/device_info_example.dart';
 import 'package:url_launcher_example/url_launcher_example.dart';
 import 'package:hive_example/hive_example.dart';
@@ -48,7 +49,7 @@ class MyApp extends StatelessWidget {
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+      home: const SplashPage(),
     );
   }
 }
@@ -99,6 +100,40 @@ class MyHomePage extends StatelessWidget {
             },
           );
         }).toList(),
+      ),
+    );
+  }
+}
+
+class SplashPage extends StatefulWidget {
+  const SplashPage({super.key});
+
+  @override
+  State<SplashPage> createState() => _SplashPageState();
+}
+
+class _SplashPageState extends State<SplashPage> {
+  @override
+  void initState() {
+    super.initState();
+    Future.delayed(const Duration(seconds: 1), () {
+      if (mounted) {
+        Navigator.of(context).pushReplacement(
+          MaterialPageRoute(
+            builder: (context) => const MyHomePage(
+              title: 'Flutter Demo Home Page',
+            ),
+          ),
+        );
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: FlutterLogo(size: 100),
       ),
     );
   }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -11,20 +11,18 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:cold_start/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
+  testWidgets('Shows splash then list view', (WidgetTester tester) async {
     await tester.pumpWidget(const MyApp());
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
+    // Initially the flutter splash should be visible.
+    expect(find.byType(FlutterLogo), findsOneWidget);
+    expect(find.text('Device Info Example'), findsNothing);
 
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
+    // Wait for the splash duration.
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pumpAndSettle();
 
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    // After the delay the list view should appear.
+    expect(find.text('Device Info Example'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- show a simple Flutter splash screen for one second
- replace the test with a check for the splash behaviour

## Testing
- `flutter test` *(fails: `flutter` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dd1161df48320ab6f11c79f74e176